### PR TITLE
Introduce quicktemplate, gojson and multi-processing

### DIFF
--- a/go-app/Dockerfile
+++ b/go-app/Dockerfile
@@ -2,9 +2,12 @@
 
 FROM golang:1.21-alpine AS build-dev
 WORKDIR /go/src/app
+RUN go install github.com/valyala/quicktemplate/qtc@v1.7.0
+RUN command -v qtc
 COPY --link go.mod ./
 RUN go version && go mod download
 COPY --link . .
+RUN go generate ./...
 RUN CGO_ENABLED=0 go install -buildvcs=false -trimpath -ldflags '-w -s'
 FROM scratch
 COPY --link --from=build-dev /go/bin/go-app /go/bin/go-app

--- a/go-app/docker-compose.yml
+++ b/go-app/docker-compose.yml
@@ -5,5 +5,11 @@ services:
     volumes:
       - ./app:/app
     working_dir: /app
-    ports:
-      - "8080:8081"
+    network_mode: host
+    #ports:
+    #  - "8080:8081"
+    environment:
+      - GOMAXPROCS=4
+    deploy:
+      mode: replicated
+      replicas: 4

--- a/go-app/go.mod
+++ b/go-app/go.mod
@@ -1,3 +1,14 @@
 module go-app
 
 go 1.21
+
+require (
+	github.com/goccy/go-json v0.10.3
+	github.com/libp2p/go-reuseport v0.4.0
+	github.com/valyala/quicktemplate v1.7.0
+)
+
+require (
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
+)

--- a/go-app/main.go
+++ b/go-app/main.go
@@ -1,11 +1,18 @@
+//go:generate go get -u github.com/valyala/quicktemplate/qtc
+//go:generate qtc -dir=templates
 package main
 
 import (
 	"encoding/json"
 	"fmt"
+	gojson "github.com/goccy/go-json"
+	"github.com/libp2p/go-reuseport"
+	_ "github.com/valyala/quicktemplate"
+	"go-app/templates"
 	"html/template"
 	"log"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 )
 
@@ -35,5 +42,48 @@ func main() {
 		}
 		fmt.Fprintln(w, "</ul></body></html>")
 	})
-	http.ListenAndServe(":8081", nil)
+	http.HandleFunc("/qtpl", func(w http.ResponseWriter, r *http.Request) {
+		log.Println(r.URL.Path)
+		b, err := os.ReadFile("input.json")
+		if err != nil {
+			log.Println(err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		var data []string
+		err = json.Unmarshal(b, &data)
+		if err != nil {
+			log.Println(err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprintln(w, "<html><body><ul>")
+		fmt.Fprintln(w, templates.HTML(data))
+		fmt.Fprintln(w, "</ul></body></html>")
+	})
+	http.HandleFunc("/qtpl_gojson", func(w http.ResponseWriter, r *http.Request) {
+		log.Println(r.URL.Path)
+		b, err := os.ReadFile("input.json")
+		if err != nil {
+			log.Println(err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		var data []string
+		err = gojson.Unmarshal(b, &data)
+		if err != nil {
+			log.Println(err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprintln(w, "<html><body><ul>")
+		fmt.Fprintln(w, templates.HTML(data))
+		fmt.Fprintln(w, "</ul></body></html>")
+	})
+
+	listener, err := reuseport.Listen("tcp4", ":8080")
+	if err != nil {
+		log.Panic(err)
+	}
+	http.Serve(listener, nil)
 }

--- a/go-app/templates/app.qtpl
+++ b/go-app/templates/app.qtpl
@@ -1,0 +1,7 @@
+{% func HTML(input []string) %}
+
+{% for _, s := range input %}
+<li>{%s s %}</li>
+{% endfor %}
+
+{% endfunc %}

--- a/go-app/templates/doc.go
+++ b/go-app/templates/doc.go
@@ -1,0 +1,3 @@
+// Templates using quicktemplate.
+// https://github.com/valyala/quicktemplate
+package templates


### PR DESCRIPTION
# 概要
go-appとphp-appのやっていることの差分をなるべく増やさないようにしながら、go-appを高速化してみました。修正内容とベンチマーク結果をここに記載しておきます。

関連スレッド: https://twitter.com/yuuki0xff/status/1803444994726044007

マージは不要です。

# 修正内容

効果があったもの

- `quicktemplate` ← html/templateが遅いので効果があった
- `GOMAXPROCS`、マルチプロセス化

効果がよくわからないもの

- `gojson` ← twitterに記載の通りシングルプロセスのときは効果があったが、マルチプロセス化したらほとんど性能には変化が無かった。原因は調査していない。

# 測定環境:

```
  Debian 12 on QEMU KVM on Linux
  Linux 6.1.0-21-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.90-1 (2024-05-03) x86_64 GNU/Linux
  Docker 26.1.4
  vCPU 16
  RAM 8GiB
  Swap 0GiB
  ホスト側CPU EPYC第2世代
  QEMUに対するCPU Pinning有効
```

# 測定条件:

```
  taskset --cpu-list 14-15 ab -n 100000 -c 50 http://127.0.0.1:ポート番号/
```

元の測定条件から変更した点

1. 測定時間が短すぎてゆらぎが多かったため、リクエスト数を増やし、計測時間を長くした。
3. vCPUを使い切れないのでスレッド数を増やした
4. abが複数CPUに分散してしまうと性能が安定しないため、tasksetで特定のvCPUに固定した。これは使用している仮想環境の影響かもしれない。

# 測定結果 (概要):

```
  PHP 8 fpm opcache                                      - 17428.51 req/sec
  Go stdlib縛り GOMAXPROCS=4 4 process負荷分散           - 5653.97 req/sec
  Go quicktemplate GOMAXPROCS=4 4 process負荷分散        - 18233.93 req/sec
  Go quicktemplate gojson GOMAXPROCS=4 4 process負荷分散 - 17491.21 req/sec
```

計測は1回のみ。~10%くらいの測定誤差はありそうです。
どのテストケースも、vCPU 16個を70%~100%くらい使っていました。

# 測定結果:

コミットメッセージに記載しています。